### PR TITLE
Fix for missing accents in application name

### DIFF
--- a/Windows/uecommunication.py
+++ b/Windows/uecommunication.py
@@ -44,7 +44,7 @@ class uecommunication(object):
     def printable(self, s):
         import string
         s = s.replace('&','&amp;')
-        return filter(lambda x: x in string.printable, s)
+        return ''.join([ch for ch in s if ord(ch) > 31 or ord(ch) == 9])
 
     @staticmethod
     def send_xml(url,xml,action,options = None):


### PR DESCRIPTION
When there are accents in applications names, they are not transmitted to the server due to a missing unicode support of "uecommunication.printable" function.
I get help with this page : http://techietrivia.blogspot.fr/2013/03/python-remove-non-printable-characters.html
