### PR TITLE
Add Windows PyInstaller build and Inno Setup script

### DIFF
--- a/LinuxDpkg/setup/install-updatengine-client.sh
+++ b/LinuxDpkg/setup/install-updatengine-client.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+## Debian/Ubuntu installation script
+
+## One shot installation command (just specify your UE-SERVER_IP) :
+#
+# wget -O /tmp/install-updatengine-client.sh https://raw.githubusercontent.com/noelmartinon/updatengine-client/nm-dev/LinuxDpkg/setup/install-updatengine-client.sh --no-check-certificate && chmod +x /tmp/install-updatengine-client.sh && sudo /tmp/install-updatengine-client.sh "https://UE-SERVER_IP:1979"
+##
+
+# Only root can run this script
+if [ "$(id -u)" != "0" ]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+apt-get install python-dmidecode python-libxml2 python-lxml python-netifaces git-core
+cd /opt
+git clone https://github.com/noelmartinon/updatengine-client.git
+chmod +x /opt/updatengine-client/LinuxDpkg/updatengine-client.py
+echo "*/30 * * * *   root   /opt/updatengine-client/LinuxDpkg/updatengine-client.py -i -s $1" > /etc/cron.d/updatengine-client
+/opt/updatengine-client/LinuxDpkg/updatengine-client.py -i -s $1

--- a/LinuxDpkg/setup/install-updatengine-client.sh
+++ b/LinuxDpkg/setup/install-updatengine-client.sh
@@ -2,7 +2,7 @@
 
 ## Debian/Ubuntu installation script
 
-## One shot installation command (just specify your UE-SERVER_IP) :
+## One shot installation command (just specify your UE-SERVER_URL and optionally the execution delay) :
 #
 # wget -O /tmp/install-updatengine-client.sh https://raw.githubusercontent.com/noelmartinon/updatengine-client/nm-dev/LinuxDpkg/setup/install-updatengine-client.sh --no-check-certificate && chmod +x /tmp/install-updatengine-client.sh && sudo /tmp/install-updatengine-client.sh "https://UE-SERVER_IP:1979"
 ##
@@ -13,9 +13,24 @@ if [ "$(id -u)" != "0" ]; then
    exit 1
 fi
 
-apt-get install python-dmidecode python-libxml2 python-lxml python-netifaces git-core
+UE_url=$1
+UE_delay=$2
+
+if [ -z "$UE_url" ];
+ then
+   echo "The UpdatEngine web server is required" 1>&2
+   exit 1
+fi
+
+if [ -z "$UE_delay" ];
+ then
+   echo "Delay is set to default value (30 minutes)" 1>&2
+   UE_delay=30
+fi
+
+apt-get install python-dmidecode python-libxml2 python-lxml python-netifaces python-psutil git-core
 cd /opt
 git clone https://github.com/noelmartinon/updatengine-client.git
 chmod +x /opt/updatengine-client/LinuxDpkg/updatengine-client.py
-echo "*/30 * * * *   root   /opt/updatengine-client/LinuxDpkg/updatengine-client.py -i -s $1" > /etc/cron.d/updatengine-client
-/opt/updatengine-client/LinuxDpkg/updatengine-client.py -i -s $1
+echo "*/$UE_delay * * * *   root   /opt/updatengine-client/LinuxDpkg/updatengine-client.py -i -s $UE_url -m $UE_delay" > /etc/cron.d/updatengine-client
+nohup /opt/updatengine-client/LinuxDpkg/updatengine-client.py -i -s $UE_url -m $UE_delay >/dev/null 2>&1 &

--- a/LinuxDpkg/uecommunication.py
+++ b/LinuxDpkg/uecommunication.py
@@ -1,4 +1,3 @@
-
 ###############################################################################
 # UpdatEngine - Software Packages Deployment and Administration tool          #
 #                                                                             #
@@ -28,6 +27,8 @@ from ueerrors import *
 
 class uecommunication(object):
 
+    ssl_version = ssl.PROTOCOL_SSLv23
+
     def check_ssl(self, hostname, port, cafile_local):
         try:
             open(cafile_local,'r')
@@ -36,7 +37,7 @@ class uecommunication(object):
             raise
 
         try:
-            ssl.get_server_certificate((hostname, port), ca_certs=cafile_local)
+            ssl.get_server_certificate((hostname, port), ssl_version=self.ssl_version, ca_certs=cafile_local)
         except ssl.SSLError:
             print "Error in check_ssl (ssl.get_server_certificate function)"
             raise ssl.SSLError('SSL cert of Host:'+str(hostname)+' Port:'+str(port)+' is invalid')  
@@ -44,7 +45,7 @@ class uecommunication(object):
     def printable(self, s):
         import string
         s = s.replace('&','&amp;')
-        return filter(lambda x: x in string.printable, s)
+        return ''.join([ch for ch in s if ord(ch) > 31 or ord(ch) == 9])
 
     @staticmethod
     def send_xml(url,xml,action,options = None):
@@ -72,9 +73,9 @@ class uecommunication(object):
                 raise
         if options.noproxy is not None:
             proxy_handler = urllib2.ProxyHandler({})
-            opener = urllib2.build_opener( urllib2.HTTPSHandler(), cookieHandler, proxy_handler )
+            opener = urllib2.build_opener( urllib2.HTTPSHandler(context=ssl.SSLContext(self.ssl_version)), cookieHandler, proxy_handler )
         else:  
-            opener = urllib2.build_opener( urllib2.HTTPSHandler(), cookieHandler )
+            opener = urllib2.build_opener( urllib2.HTTPSHandler(context=ssl.SSLContext(self.ssl_version)), cookieHandler )
         urllib2.install_opener( opener )
         
         try:
@@ -148,9 +149,9 @@ class uecommunication(object):
                 raise
         if options.noproxy is not None:
             proxy_handler = urllib2.ProxyHandler({})
-            opener = urllib2.build_opener( urllib2.HTTPSHandler(), cookieHandler, proxy_handler )
+            opener = urllib2.build_opener( urllib2.HTTPSHandler(context=ssl.SSLContext(self.ssl_version)), cookieHandler, proxy_handler )
         else:  
-            opener = urllib2.build_opener( urllib2.HTTPSHandler(), cookieHandler )
+            opener = urllib2.build_opener( urllib2.HTTPSHandler(context=ssl.SSLContext(self.ssl_version)), cookieHandler )
         urllib2.install_opener( opener )
                 
         try:

--- a/LinuxDpkg/ueinventory.py
+++ b/LinuxDpkg/ueinventory.py
@@ -25,6 +25,9 @@ import subprocess
 import os
 import dmidecode
 import hashlib
+import psutil
+
+
 class ueinventory(object):
 
     @staticmethod
@@ -107,7 +110,7 @@ class ueinventory(object):
 
     def get_username(self):
         try:
-            return os.getlogin()
+            return psutil.users()[0].name
         except:
             return 'undefined'
         
@@ -217,6 +220,5 @@ class ueinventory(object):
                 <Systemdrive>"+line[3].strip()+"</Systemdrive>\n\
                 </Osdistribution>\n"
         return osdata
-
 
 

--- a/LinuxDpkg/ueinventory.py
+++ b/LinuxDpkg/ueinventory.py
@@ -1,3 +1,4 @@
+
 ###############################################################################
 # UpdatEngine - Software Packages Deployment and Administration tool          #
 #                                                                             #
@@ -53,12 +54,14 @@ class ueinventory(object):
             softsum = str(hashlib.md5(softwaredata).hexdigest()) 
             netdata = self.format_netlist(self.get_netlist())
             netsum =  str(hashlib.md5(netdata).hexdigest())
+            username = self.get_username()
+
             data = "<Inventory>\n\
                 <Hostname>"+hostname.strip()+"</Hostname>\n\
                 <SerialNumber>"+serial.strip()+"</SerialNumber>\n\
                 <Manufacturer>"+manufacturer.strip()+"</Manufacturer>\n\
                 <Uuid>"+uuid.strip()+"</Uuid>\n\
-                <UserName>Undefined</UserName>\n\
+                <UserName>"+username.strip()+"</UserName>\n\
                 <Domain>"+domain.strip()+"</Domain>\n\
                 <Language>"+language.strip()+"</Language>\n\
                 <Product>"+product.strip()+"</Product>\n\
@@ -101,6 +104,12 @@ class ueinventory(object):
             return self.checkdmi(dmixp,'/dmidecode/SystemInfo/SystemUUID')
         except:
             return 'Unknown'
+
+    def get_username(self):
+        try:
+            return os.getlogin()
+        except:
+            return 'undefined'
         
     def get_domain(self):
         try:

--- a/LinuxDpkg/ueinventory.py
+++ b/LinuxDpkg/ueinventory.py
@@ -165,7 +165,10 @@ class ueinventory(object):
             try:
                 ip = netifaces.ifaddresses(net)[netifaces.AF_INET][0]['addr']
                 mask = netifaces.ifaddresses(net)[netifaces.AF_INET][0]['netmask']
-                mac = netifaces.ifaddresses(net)[netifaces.AF_LINK][0]['addr']
+                try:
+                    mac = netifaces.ifaddresses(net)[netifaces.AF_LINK][0]['addr']
+                except:
+                    mac = "00:00:00:00:00:00"
                 netlist.append(ip+','+mask+','+mac)
             except :
                 pass

--- a/LinuxDpkg/updatengine-client.py
+++ b/LinuxDpkg/updatengine-client.py
@@ -22,7 +22,7 @@
 ###############################################################################
 
 
-import optparse
+import argparse
 import time
 import logging
 from ueinventory import ueinventory
@@ -56,24 +56,24 @@ def wait(minutes, passphrase):
 def main():
 # Define options
 
-    parser = optparse.OptionParser("usage: %prog [options] arg1 arg2")
-    parser.add_option("-s", "--server", dest="server", \
-                   type="string", help="Your UpdatEngine server IP or DNS name")
-    parser.add_option("-i", "--inventory", dest="inventory", \
+    parser = argparse.ArgumentParser("usage: %prog [options] arg1 arg2")
+    parser.add_argument("-s", "--server", dest="server", \
+                   type=str, help="Your UpdatEngine server IP or DNS name")
+    parser.add_argument("-i", "--inventory", dest="inventory", \
                    action="store_false", help="Port of your UpdatEngine server")
-    parser.add_option("-v", "--verbose", dest="verbose", \
+    parser.add_argument("-v", "--verbose", dest="verbose", \
                    action="store_false", help="Verbose mode")
-    parser.add_option("-n", "--noproxy", dest="noproxy", \
+    parser.add_argument("-n", "--noproxy", dest="noproxy", \
                    action="store_false", help="do not use any proxy")
-    parser.add_option("-m", "--minutes", dest="minute", \
-                   type="int", help="Minute between each inventory")
-    parser.add_option("-c", "--cert", dest="cert", \
-                   type="string", help="Absolute path to cacert.pem file")
-    parser.add_option("-l", "--list", dest="list", \
+    parser.add_argument("-m", "--minutes", dest="minute", \
+                   type=int, help="Minute between each inventory")
+    parser.add_argument("-c", "--cert", dest="cert", \
+                   type=str, help="Absolute path to cacert.pem file")
+    parser.add_argument("-l", "--list", dest="list", \
                    action="store_false", help="To get public soft list")
-    parser.add_option("-g", "--get", type = "int", dest="get", \
+    parser.add_argument("-g", "--get", type=int, dest="get", \
                    help="Package number to install  manualy")
-    parser.add_option("-o", "--out", type = "string", dest="out", \
+    parser.add_argument("-o", "--out", type=str, dest="out", \
                    help="Full path to logfile")
     (options, args) = parser.parse_args()
 
@@ -181,3 +181,4 @@ if __name__ == "__main__":
         main()
     except:
         logging.exception("Error in main() function")
+

--- a/LinuxRpm/uecommunication.py
+++ b/LinuxRpm/uecommunication.py
@@ -1,4 +1,3 @@
-
 ###############################################################################
 # UpdatEngine - Software Packages Deployment and Administration tool          #
 #                                                                             #
@@ -28,6 +27,8 @@ from ueerrors import *
 
 class uecommunication(object):
 
+    ssl_version = ssl.PROTOCOL_SSLv23
+
     def check_ssl(self, hostname, port, cafile_local):
         try:
             open(cafile_local,'r')
@@ -36,7 +37,7 @@ class uecommunication(object):
             raise
 
         try:
-            ssl.get_server_certificate((hostname, port), ca_certs=cafile_local)
+            ssl.get_server_certificate((hostname, port), ssl_version=self.ssl_version, ca_certs=cafile_local)
         except ssl.SSLError:
             print "Error in check_ssl (ssl.get_server_certificate function)"
             raise ssl.SSLError('SSL cert of Host:'+str(hostname)+' Port:'+str(port)+' is invalid')  
@@ -44,7 +45,7 @@ class uecommunication(object):
     def printable(self, s):
         import string
         s = s.replace('&','&amp;')
-        return filter(lambda x: x in string.printable, s)
+        return ''.join([ch for ch in s if ord(ch) > 31 or ord(ch) == 9])
 
     @staticmethod
     def send_xml(url,xml,action,options = None):
@@ -72,9 +73,9 @@ class uecommunication(object):
                 raise
         if options.noproxy is not None:
             proxy_handler = urllib2.ProxyHandler({})
-            opener = urllib2.build_opener( urllib2.HTTPSHandler(), cookieHandler, proxy_handler )
+            opener = urllib2.build_opener( urllib2.HTTPSHandler(context=ssl.SSLContext(self.ssl_version)), cookieHandler, proxy_handler )
         else:  
-            opener = urllib2.build_opener( urllib2.HTTPSHandler(), cookieHandler )
+            opener = urllib2.build_opener( urllib2.HTTPSHandler(context=ssl.SSLContext(self.ssl_version)), cookieHandler )
         urllib2.install_opener( opener )
         
         try:
@@ -148,9 +149,9 @@ class uecommunication(object):
                 raise
         if options.noproxy is not None:
             proxy_handler = urllib2.ProxyHandler({})
-            opener = urllib2.build_opener( urllib2.HTTPSHandler(), cookieHandler, proxy_handler )
+            opener = urllib2.build_opener( urllib2.HTTPSHandler(context=ssl.SSLContext(self.ssl_version)), cookieHandler, proxy_handler )
         else:  
-            opener = urllib2.build_opener( urllib2.HTTPSHandler(), cookieHandler )
+            opener = urllib2.build_opener( urllib2.HTTPSHandler(context=ssl.SSLContext(self.ssl_version)), cookieHandler )
         urllib2.install_opener( opener )
                 
         try:

--- a/LinuxRpm/ueinventory.py
+++ b/LinuxRpm/ueinventory.py
@@ -165,7 +165,10 @@ class ueinventory(object):
             try:
                 ip = netifaces.ifaddresses(net)[netifaces.AF_INET][0]['addr']
                 mask = netifaces.ifaddresses(net)[netifaces.AF_INET][0]['netmask']
-                mac = netifaces.ifaddresses(net)[netifaces.AF_LINK][0]['addr']
+                try:
+                    mac = netifaces.ifaddresses(net)[netifaces.AF_LINK][0]['addr']
+                except:
+                    mac = "00:00:00:00:00:00"
                 netlist.append(ip+','+mask+','+mac)
             except :
                 pass

--- a/Windows/build.bat
+++ b/Windows/build.bat
@@ -1,8 +1,20 @@
 @echo off
 
+REM Install python : https://www.python.org/downloads/
+REM Install packages : python -m pip install lxml pywin32 PyInstaller
+
+set path=c:\python27;c:\python27\scripts;%path%
+
 set PathInstall=%~dp0
 
 rd /S /Q "%PathInstall%build"
 rd /S /Q "%PathInstall%dist"
-python build_cxfreeze.py build
+
+pyinstaller -y --icon=updatengine.ico --version-file=version.txt --add-data "LICENSE.txt;." --add-data "updatengine.ico;." updatengine-client.py
+
+rem OR :
+rem   pyi-makespec --icon=updatengine.ico --version-file=version.txt --add-data "LICENSE.txt;." --add-data "updatengine.ico;." updatengine-client.py
+rem   pyinstaller updatengine-client.spec
+
+rem python build_cxfreeze.py build
 rem python build_py2exe.py py2exe -p lxml

--- a/Windows/setup/install_script.iss
+++ b/Windows/setup/install_script.iss
@@ -1,0 +1,283 @@
+; Inno Setup Script for UpdatEngine-client
+; Unpacked from original updatengine-client-setup and completed by Noël MARTINON
+; The [Files] were generated with PyInstaller
+
+#define MyAppName "UpdatEngine client"
+#define MyAppVersion "2.4.9.4"
+#define MyAppPublisher "UpdatEngine"
+#define MyAppURL "http://www.updatengine.com"
+#define MyAppSetupName "updatengine-client-setup"
+#define MyAppSource "..\dist\updatengine-client"
+
+[Setup]
+AppId={{186C91F4-935B-4EEC-90B2-596F347AB706}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={pf}\{#MyAppName}
+DisableProgramGroupPage=yes
+UninstallDisplayIcon={app}/updatengine.ico
+LicenseFile="{#MyAppSource}\LICENSE.txt"
+OutputBaseFilename={#MyAppSetupName}-{#MyAppVersion}
+Compression=lzma
+SolidCompression=yes
+PrivilegesRequired=admin
+
+[Languages]
+Name: "en"; MessagesFile: "compiler:Default.isl"
+Name: "fr"; MessagesFile: "compiler:Languages\French.isl"
+
+[Files]
+Source: "{#MyAppSource}\_ctypes.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\_hashlib.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\_socket.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\_ssl.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\bz2.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\LICENSE.txt"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\lxml._elementpath.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\lxml.etree.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\Microsoft.VC90.CRT.manifest"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\msvcm90.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\msvcp90.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\msvcr90.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\pyexpat.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\python27.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\pywintypes27.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\select.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\unicodedata.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\updatengine.ico"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\updatengine-client.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\updatengine-client.exe.manifest"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\win32pipe.pyd"; DestDir: "{app}"; Flags: ignoreversion
+
+[Registry]
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment\"; ValueName: "Path"; ValueType: ExpandSZ; ValueData: "{reg:HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\,Path};{app}"; Check: "NeedsAddPath(ExpandConstant('{app}'))"; MinVersion: 0.0,5.0; 
+
+[Run]
+Filename: "{cmd}"; Parameters: "/c copy /Y ""{code:GetCacert}"" ""{app}\cacert.pem"""; Check: "not CheckEmptyCacert"; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Delete /F /TN ""Updatengine""  "; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Delete /F /TN ""Updatengine-monitor""  "; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Create /ru ""SYSTEM"" /sc ONSTART /tn ""Updatengine"" /tr "" \""{app}\updatengine-client.exe\"" -i {code:GetProxyOption} -s {code:GetServerAdress} -m {code:GetDelay} -c \""{app}\cacert.pem\"" -o \""{app}\updatengine-client.log\"" "" "; Check: "not CheckEmptyCacert"; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Create /ru ""SYSTEM"" /sc ONSTART /tn ""Updatengine"" /tr "" \""{app}\updatengine-client.exe\"" -i {code:GetProxyOption} -s {code:GetServerAdress} -m {code:GetDelay} -o \""{app}\updatengine-client.log\"" "" "; Check: "CheckEmptyCacert"; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Create /ru ""SYSTEM"" /sc MINUTE /mo 10 /tn ""Updatengine-monitor"" /tr ""schtasks.exe /RUN /TN \""Updatengine\"" "" "; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Run /tn ""Updatengine"" "" "; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "sc.exe"; Parameters: " config schedule start= auto"; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Run /tn ""Updatengine""  "; Check: "CheckNoInstallInventory"; MinVersion: 0.0,5.0; Flags: runhidden;
+
+[UninstallRun]
+Filename: "schtasks.exe"; Parameters: " /Delete /F /TN ""Updatengine""  "; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Delete /F /TN ""Updatengine-monitor""  "; MinVersion: 0.0,5.0; Flags: runhidden;
+
+[UninstallDelete]
+Type: filesandordirs; Name: "{app}"; 
+
+[CustomMessages]
+en.NameAndVersion=%1 version %2
+en.AdditionalIcons=Additional shortcuts:
+en.CreateDesktopIcon=Create a &desktop shortcut
+en.CreateQuickLaunchIcon=Create a &Quick Launch shortcut
+en.ProgramOnTheWeb=%1 on the Web
+en.UninstallProgram=Uninstall %1
+en.LaunchProgram=Launch %1
+en.AssocFileExtension=&Associate %1 with the %2 file extension
+en.AssocingFileExtension=Associating %1 with the %2 file extension...
+en.AutoStartProgramGroupDescription=Startup:
+en.AutoStartProgram=Automatically start %1
+en.AddonHostProgramNotFound=%1 could not be located in the folder you selected.%n%nDo you want to continue anyway?
+fr.NameAndVersion=%1 version %2
+fr.AdditionalIcons=Icônes supplémentaires :
+fr.CreateDesktopIcon=Créer une icône sur le &Bureau
+fr.CreateQuickLaunchIcon=Créer une icône dans la barre de &Lancement rapide
+fr.ProgramOnTheWeb=Page d'accueil de %1
+fr.UninstallProgram=Désinstaller %1
+fr.LaunchProgram=Exécuter %1
+fr.AssocFileExtension=&Associer %1 avec l'extension de fichier %2
+fr.AssocingFileExtension=Associe %1 avec l'extension de fichier %2...
+fr.AutoStartProgramGroupDescription=Démarrage :
+fr.AutoStartProgram=Démarrer automatiquement %1
+fr.AddonHostProgramNotFound=%1 n'a pas été trouvé dans le dossier que vous avez choisi.%n%nVoulez-vous continuer malgré tout ?
+en.TitleConfiguration=UpdatEngine client configuration
+en.SubTitleConfiguration=Configure UpatdEngine server adress and delay
+en.TipsConfiguration=Please enter your UpdatEngine''s server adress and the delay between each inventory (in minutes)
+en.Server=Updatengine server url
+en.Delay=Delay between each inventory (minutes)
+en.UrlValue=https://your_updatengine_server:1979
+en.SslCertificate=SSL certificate
+en.SslTips=Select your cacert.pem file if needed
+en.SslWarning=Warning: without selecting a cacert.pem file, your installation will vulnerable to MITM attacks. For more information, please consult updatengine client documentation
+en.SslField=Select your webserver's SSL certificate
+en.ProxyTitle=Proxy configuration
+en.ProxyDescription=Use or not system proxy
+en.ProxyHeader=By default (unchecked), UpdatEngine client will use Internet Explorer proxy settings.
+en.ProxyBox=Check this box to disable Internet Explorer Proxy settings for Updatengine Client.
+en.NoInstallInventoryTitle=Initial Inventory
+en.NoInstallInventoryDescription=Launch inventory after Updatengine install
+en.NoInstallInventoryHeader=By default (unchecked), UpdatEngine will launch an inventory after install.
+en.NoInstallInventory= Check this box to disable UpdatEngine inventory after install.
+fr.TitleConfiguration=Configuration du client UpdatEngine
+fr.SubTitleConfiguration=Configuration de l'adresse du serveur et des délais d'inventaires
+fr.TipsConfiguration=Saisissez dans les deux champs suivants l'adresse du serveur UpdatEngine et le délais d'inventaire
+fr.Server=Adresse (http ou https) du serveur UpdatEngine
+fr.Delay=Délais d'attente entre deux inventaires (en minutes)
+fr.UrlValue=https://votre_serveur_updatengine:1979
+fr.SslCertificate=Certificat SSL
+fr.SslTips=Choisissez le certificat SSL propre à ce serveur
+fr.SslWarning=Attention: Sans certificat de sécurité, votre client sera vulnérable à une attaque de type MITM. Référez-vous à la documentation du client pour plus d'informations
+fr.SslField=Choisissez ici le certificat SSL de votre serveur Web.
+fr.ProxyTitle=Paramètres de proxy
+fr.ProxyDescription=Utilisation du proxy Internet Explorer pour le client UpdatEngine
+fr.ProxyHeader=Par défaut (case décochée), le client UpdatEngine utilisera les paramètres du proxy Internet Explorer.
+fr.ProxyBox=Cochez cette case pour ne pas utiliser le Proxy déclaré dans Internet Explorer
+fr.NoInstallInventoryTitle=Inventaire intial
+fr.NoInstallInventoryDescription=Lancement d'un inventaire après installation
+fr.NoInstallInventoryHeader=Par défaut (case décochée), le client UpdatEngine lancera un inventaire dès la fin d'installation.
+fr.NoInstallInventory= Cochez cette case pour ne pas lancer d'inventaire après l'installation
+en.AllFiles=All files
+en.PemFiles=PEM SSL Certificat
+fr.AllFiles=Tous les fichiers
+fr.PemFiles=Certificat SSL PEM
+en.SslCertError=File does not exist or is emtpy. Please select the correct file.
+fr.SslCertError=Le fichier n'existe pas ou est vide. Veuillez sélectionner un fichier correct.
+
+[Code]
+var    
+  ConfigPage: TInputQueryWizardPage;
+  InventoryPage: TInputOptionWizardPage;
+  ProxyPage: TInputOptionWizardPage;
+  SslCertificatePage: TInputFileWizardPage;
+
+// --------------------------------
+// Wizard initialization : Create the pages 
+procedure InitializeWizard;        
+begin
+  { Config page }
+  ConfigPage := CreateInputQueryPage(wpLicense,
+    expandConstant('{cm:TitleConfiguration}'), ExpandConstant('{cm:SubTitleConfiguration}'),
+    expandConstant('{cm:TipsConfiguration}'));
+  ConfigPage.Add(expandConstant('{cm:Server}'), False);
+  ConfigPage.Add(expandConstant('{cm:Delay}'), False);
+
+  ConfigPage.Values[0] := GetPreviousData('Server', ExpandConstant('{cm:UrlValue}'));
+  ConfigPage.Values[1] := GetPreviousData('Delay', '30');
+
+  { Inventory page }
+  InventoryPage := CreateInputOptionPage(ConfigPage.ID,
+    expandConstant('{cm:NoInstallInventoryTitle}'), expandConstant('{cm:NoInstallInventoryDescription}'),
+    expandConstant('{cm:NoInstallInventoryHeader}'),
+    False, False);
+  InventoryPage.Add(expandConstant('{cm:NoInstallInventory}'));
+  
+  if GetPreviousData('NoInstallInventory', '') = 'True' then
+    InventoryPage.Values[0] := True;
+
+  { Proxy page }
+  ProxyPage := CreateInputOptionPage(InventoryPage.ID,
+    expandConstant('{cm:ProxyTitle}'), expandConstant('{cm:ProxyDescription}'),
+    expandConstant('{cm:ProxyHeader}'),
+    False, False);
+  ProxyPage.Add(expandConstant('{cm:ProxyBox}'));
+
+  if GetPreviousData('ProxyBox', '') = 'True' then
+    ProxyPage.Values[0] := True;
+
+  { Certificate page }
+  SslCertificatePage := CreateInputFilePage(ProxyPage.ID,
+    expandConstant('{cm:SslCertificate}'), expandConstant('{cm:SslTips}'),
+    expandConstant('{cm:SslWarning}'));  
+  SslCertificatePage.Add(expandConstant('{cm:SslField}'),
+    expandConstant('{cm:PemFiles}|*.pem|{cm:AllFiles}|*.*'), '.pem');
+
+  SslCertificatePage.Values[0] := GetPreviousData('SslField', '');
+end;
+
+// --------------------------------
+// Store the settings so we can restore them next time
+procedure RegisterPreviousData(PreviousDataKey: Integer);
+begin  
+  SetPreviousData(PreviousDataKey, 'Server', ConfigPage.Values[0]);
+  SetPreviousData(PreviousDataKey, 'Delay', ConfigPage.Values[1]);
+  if InventoryPage.Values[0] = True then
+    SetPreviousData(PreviousDataKey, 'NoInstallInventory', 'True');
+  if ProxyPage.Values[0] = True then
+    SetPreviousData(PreviousDataKey, 'ProxyBox', 'True');
+  SetPreviousData(PreviousDataKey, 'SslField', SslCertificatePage.Values[0]);
+end;
+
+// --------------------------------
+// Check if it is needed to add '{app}' path to registry
+function NeedsAddPath(Param: string): boolean;
+var
+  OrigPath: string;
+begin
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE,'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'Path', OrigPath)
+  then begin
+    Result := True;
+    exit;
+  end;
+  // look for the path with leading and trailing semicolon
+  Result := Pos(';' + UpperCase(Param) + ';', ';' + UpperCase(OrigPath) + ';') = 0;   
+  if Result = True then
+     Result := Pos(';' + UpperCase(Param) + '\;', ';' + UpperCase(OrigPath) + ';') = 0; 
+end;
+
+// --------------------------------
+// Get certificat file string
+function GetCacert(Value: string): string;
+begin
+  Result := SslCertificatePage.Values[0];
+end;
+
+// --------------------------------
+// Get proxy use option
+function GetProxyOption(Value: string): string;
+begin
+  if ProxyPage.Values[0] then
+    Result := '/noproxy';
+end;                   
+
+// --------------------------------
+// Get server string
+function GetServerAdress(Value: string): string;
+begin
+  Result := ConfigPage.Values[0];
+end;   
+
+// --------------------------------
+// Get delay value
+function GetDelay(Value: string): string;
+begin
+  Result := ConfigPage.Values[1];
+end;   
+
+// --------------------------------
+// Check if inventory is launched after installation
+function CheckNoInstallInventory: Boolean;
+begin
+  if not InventoryPage.Values[0] then
+    Result := True;
+end; 
+
+// --------------------------------
+// Check if certificat file is empty
+function CheckEmptyCacert: Boolean;
+var
+  Size: Integer;
+begin       
+    if not FileSize(SslCertificatePage.Values[0], Size) or (Size = 0) then
+      Result := True;
+end;
+
+// --------------------------------
+// Check certificat file on next button click
+function NextButtonClick(PageId: Integer): Boolean;
+begin
+    Result := True;
+    if (PageId = SslCertificatePage.ID) and (SslCertificatePage.Values[0]<>'') and CheckEmptyCacert then begin
+        MsgBox(expandConstant('{cm:SslCertError}'), mbError, MB_OK);
+        Result := False;
+        exit;
+    end;
+end;

--- a/Windows/setup/install_script.iss
+++ b/Windows/setup/install_script.iss
@@ -1,25 +1,29 @@
 ; Inno Setup Script for UpdatEngine-client
 ; Unpacked from original updatengine-client-setup and completed by Noël MARTINON
 ; The [Files] were generated with PyInstaller
+;
+; Specific command line arguments : server, delay, cert, noproxy, noinventorynow, nolog, forceinstall
+;
 
 #define MyAppName "UpdatEngine client"
 #define MyAppVersion "2.4.9.4"
 #define MyAppPublisher "UpdatEngine"
-#define MyAppURL "http://www.updatengine.com"
+#define MyAppURL "https://github.com/noelmartinon/updatengine-client"
 #define MyAppSetupName "updatengine-client-setup"
 #define MyAppSource "..\dist\updatengine-client"
 
 [Setup]
-AppId={{186C91F4-935B-4EEC-90B2-596F347AB706}
+AppId={{74B4EB48-7DE3-4708-B36D-7D40F1426658}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
+VersionInfoVersion={#MyAppVersion}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={pf}\{#MyAppName}
 DisableProgramGroupPage=yes
-UninstallDisplayIcon={app}/updatengine.ico
+UninstallDisplayIcon={app}\updatengine.ico
 LicenseFile="{#MyAppSource}\LICENSE.txt"
 OutputBaseFilename={#MyAppSetupName}-{#MyAppVersion}
 Compression=lzma
@@ -31,27 +35,27 @@ Name: "en"; MessagesFile: "compiler:Default.isl"
 Name: "fr"; MessagesFile: "compiler:Languages\French.isl"
 
 [Files]
-Source: "{#MyAppSource}\_ctypes.pyd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\_hashlib.pyd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\_socket.pyd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\_ssl.pyd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\bz2.pyd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\LICENSE.txt"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\lxml._elementpath.pyd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\lxml.etree.pyd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\Microsoft.VC90.CRT.manifest"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\msvcm90.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\msvcp90.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\msvcr90.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\pyexpat.pyd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\python27.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\pywintypes27.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\select.pyd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\unicodedata.pyd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\updatengine.ico"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\updatengine-client.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\updatengine-client.exe.manifest"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppSource}\win32pipe.pyd"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppSource}\_ctypes.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion; BeforeInstall: CheckForceInstall()
+Source: "{#MyAppSource}\_hashlib.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\_socket.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\_ssl.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\bz2.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\LICENSE.txt"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\lxml._elementpath.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\lxml.etree.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\Microsoft.VC90.CRT.manifest"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\msvcm90.dll"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\msvcp90.dll"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\msvcr90.dll"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\pyexpat.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\python27.dll"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\pywintypes27.dll"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\select.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\unicodedata.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\updatengine.ico"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\updatengine-client.exe"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\updatengine-client.exe.manifest"; DestDir: "{app}"; Flags: restartreplace ignoreversion
+Source: "{#MyAppSource}\win32pipe.pyd"; DestDir: "{app}"; Flags: restartreplace ignoreversion
 
 [Registry]
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment\"; ValueName: "Path"; ValueType: ExpandSZ; ValueData: "{reg:HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\,Path};{app}"; Check: "NeedsAddPath(ExpandConstant('{app}'))"; MinVersion: 0.0,5.0; 
@@ -60,16 +64,17 @@ Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environmen
 Filename: "{cmd}"; Parameters: "/c copy /Y ""{code:GetCacert}"" ""{app}\cacert.pem"""; Check: "not CheckEmptyCacert"; MinVersion: 0.0,5.0; Flags: runhidden;
 Filename: "schtasks.exe"; Parameters: " /Delete /F /TN ""Updatengine""  "; MinVersion: 0.0,5.0; Flags: runhidden;
 Filename: "schtasks.exe"; Parameters: " /Delete /F /TN ""Updatengine-monitor""  "; MinVersion: 0.0,5.0; Flags: runhidden;
-Filename: "schtasks.exe"; Parameters: " /Create /ru ""SYSTEM"" /sc ONSTART /tn ""Updatengine"" /tr "" \""{app}\updatengine-client.exe\"" -i {code:GetProxyOption} -s {code:GetServerAdress} -m {code:GetDelay} -c \""{app}\cacert.pem\"" -o \""{app}\updatengine-client.log\"" "" "; Check: "not CheckEmptyCacert"; MinVersion: 0.0,5.0; Flags: runhidden;
-Filename: "schtasks.exe"; Parameters: " /Create /ru ""SYSTEM"" /sc ONSTART /tn ""Updatengine"" /tr "" \""{app}\updatengine-client.exe\"" -i {code:GetProxyOption} -s {code:GetServerAdress} -m {code:GetDelay} -o \""{app}\updatengine-client.log\"" "" "; Check: "CheckEmptyCacert"; MinVersion: 0.0,5.0; Flags: runhidden;
-Filename: "schtasks.exe"; Parameters: " /Create /ru ""SYSTEM"" /sc MINUTE /mo 10 /tn ""Updatengine-monitor"" /tr ""schtasks.exe /RUN /TN \""Updatengine\"" "" "; MinVersion: 0.0,5.0; Flags: runhidden;
-Filename: "schtasks.exe"; Parameters: " /Run /tn ""Updatengine"" "" "; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Create /ru ""SYSTEM"" /sc ONSTART /tn ""Updatengine"" /tr "" \""{app}\updatengine-client.exe\"" -i {code:GetProxyOption} -s {code:GetServerAdress} -m {code:GetDelay} -c \""{app}\cacert.pem\"" {code:GetLogging} "" "; Check: "not CheckEmptyCacert"; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Create /ru ""SYSTEM"" /sc ONSTART /tn ""Updatengine"" /tr "" \""{app}\updatengine-client.exe\"" -i {code:GetProxyOption} -s {code:GetServerAdress} -m {code:GetDelay} {code:GetLogging} "" "; Check: "CheckEmptyCacert"; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Create /ru ""SYSTEM"" /sc MINUTE /mo 10 /tn ""Updatengine-monitor"" /tr ""schtasks.exe /Run /tn \""Updatengine\"" "" "; MinVersion: 0.0,5.0; Flags: runhidden;
 Filename: "sc.exe"; Parameters: " config schedule start= auto"; MinVersion: 0.0,5.0; Flags: runhidden;
-Filename: "schtasks.exe"; Parameters: " /Run /tn ""Updatengine""  "; Check: "CheckNoInstallInventory"; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "schtasks.exe"; Parameters: " /Run /tn ""Updatengine"" "; Check: "CheckNoInstallInventory"; MinVersion: 0.0,5.0; Flags: runhidden;
 
 [UninstallRun]
 Filename: "schtasks.exe"; Parameters: " /Delete /F /TN ""Updatengine""  "; MinVersion: 0.0,5.0; Flags: runhidden;
 Filename: "schtasks.exe"; Parameters: " /Delete /F /TN ""Updatengine-monitor""  "; MinVersion: 0.0,5.0; Flags: runhidden;
+Filename: "taskkill.exe"; Parameters: "/f /t /im updatengine-client.exe"; Flags: runhidden
+Filename: "ping.exe"; Parameters: "127.0.0.1 -n 1"; Flags: runhidden
 
 [UninstallDelete]
 Type: filesandordirs; Name: "{app}"; 
@@ -87,18 +92,6 @@ en.AssocingFileExtension=Associating %1 with the %2 file extension...
 en.AutoStartProgramGroupDescription=Startup:
 en.AutoStartProgram=Automatically start %1
 en.AddonHostProgramNotFound=%1 could not be located in the folder you selected.%n%nDo you want to continue anyway?
-fr.NameAndVersion=%1 version %2
-fr.AdditionalIcons=Icônes supplémentaires :
-fr.CreateDesktopIcon=Créer une icône sur le &Bureau
-fr.CreateQuickLaunchIcon=Créer une icône dans la barre de &Lancement rapide
-fr.ProgramOnTheWeb=Page d'accueil de %1
-fr.UninstallProgram=Désinstaller %1
-fr.LaunchProgram=Exécuter %1
-fr.AssocFileExtension=&Associer %1 avec l'extension de fichier %2
-fr.AssocingFileExtension=Associe %1 avec l'extension de fichier %2...
-fr.AutoStartProgramGroupDescription=Démarrage :
-fr.AutoStartProgram=Démarrer automatiquement %1
-fr.AddonHostProgramNotFound=%1 n'a pas été trouvé dans le dossier que vous avez choisi.%n%nVoulez-vous continuer malgré tout ?
 en.TitleConfiguration=UpdatEngine client configuration
 en.SubTitleConfiguration=Configure UpatdEngine server adress and delay
 en.TipsConfiguration=Please enter your UpdatEngine''s server adress and the delay between each inventory (in minutes)
@@ -111,12 +104,31 @@ en.SslWarning=Warning: without selecting a cacert.pem file, your installation wi
 en.SslField=Select your webserver's SSL certificate
 en.ProxyTitle=Proxy configuration
 en.ProxyDescription=Use or not system proxy
-en.ProxyHeader=By default (unchecked), UpdatEngine client will use Internet Explorer proxy settings.
-en.ProxyBox=Check this box to disable Internet Explorer Proxy settings for Updatengine Client.
+en.ProxyHeader=By default (unchecked), UpdatEngine client will use internet proxy settings.
+en.ProxyBox=Check this box to disable internet proxy settings for Updatengine Client.
 en.NoInstallInventoryTitle=Initial Inventory
 en.NoInstallInventoryDescription=Launch inventory after Updatengine install
 en.NoInstallInventoryHeader=By default (unchecked), UpdatEngine will launch an inventory after install.
-en.NoInstallInventory= Check this box to disable UpdatEngine inventory after install.
+en.NoInstallInventoryBox=Check this box to disable UpdatEngine inventory after install.
+en.AllFiles=All files
+en.PemFiles=PEM SSL Certificat
+en.SslCertError=File does not exist or is emtpy. Please select the correct file.
+en.LogTitle=Event log
+en.LogDescription=Log of the application activity
+en.LogHeader=By default (unchecked), UpdatEngine Client logs its activity in its installation directory.
+en.LogBox=Check this box to disable UpdatEngine Client logging
+fr.NameAndVersion=%1 version %2
+fr.AdditionalIcons=Icônes supplémentaires :
+fr.CreateDesktopIcon=Créer une icône sur le &Bureau
+fr.CreateQuickLaunchIcon=Créer une icône dans la barre de &Lancement rapide
+fr.ProgramOnTheWeb=Page d'accueil de %1
+fr.UninstallProgram=Désinstaller %1
+fr.LaunchProgram=Exécuter %1
+fr.AssocFileExtension=&Associer %1 avec l'extension de fichier %2
+fr.AssocingFileExtension=Associe %1 avec l'extension de fichier %2...
+fr.AutoStartProgramGroupDescription=Démarrage :
+fr.AutoStartProgram=Démarrer automatiquement %1
+fr.AddonHostProgramNotFound=%1 n'a pas été trouvé dans le dossier que vous avez choisi.%n%nVoulez-vous continuer malgré tout ?
 fr.TitleConfiguration=Configuration du client UpdatEngine
 fr.SubTitleConfiguration=Configuration de l'adresse du serveur et des délais d'inventaires
 fr.TipsConfiguration=Saisissez dans les deux champs suivants l'adresse du serveur UpdatEngine et le délais d'inventaire
@@ -128,19 +140,20 @@ fr.SslTips=Choisissez le certificat SSL propre à ce serveur
 fr.SslWarning=Attention: Sans certificat de sécurité, votre client sera vulnérable à une attaque de type MITM. Référez-vous à la documentation du client pour plus d'informations
 fr.SslField=Choisissez ici le certificat SSL de votre serveur Web.
 fr.ProxyTitle=Paramètres de proxy
-fr.ProxyDescription=Utilisation du proxy Internet Explorer pour le client UpdatEngine
-fr.ProxyHeader=Par défaut (case décochée), le client UpdatEngine utilisera les paramètres du proxy Internet Explorer.
-fr.ProxyBox=Cochez cette case pour ne pas utiliser le Proxy déclaré dans Internet Explorer
+fr.ProxyDescription=Utilisation du proxy internet du système pour le client UpdatEngine
+fr.ProxyHeader=Par défaut (case décochée), le client UpdatEngine utilisera les paramètres du proxy définis dans les options internet du système.
+fr.ProxyBox=Cochez cette case pour ne pas utiliser le proxy internet du système
 fr.NoInstallInventoryTitle=Inventaire intial
 fr.NoInstallInventoryDescription=Lancement d'un inventaire après installation
 fr.NoInstallInventoryHeader=Par défaut (case décochée), le client UpdatEngine lancera un inventaire dès la fin d'installation.
-fr.NoInstallInventory= Cochez cette case pour ne pas lancer d'inventaire après l'installation
-en.AllFiles=All files
-en.PemFiles=PEM SSL Certificat
+fr.NoInstallInventoryBox=Cochez cette case pour ne pas lancer d'inventaire après l'installation
 fr.AllFiles=Tous les fichiers
 fr.PemFiles=Certificat SSL PEM
-en.SslCertError=File does not exist or is emtpy. Please select the correct file.
 fr.SslCertError=Le fichier n'existe pas ou est vide. Veuillez sélectionner un fichier correct.
+fr.LogTitle=Journal d'événements
+fr.LogDescription=Enregitrement de l'activité de l'application
+fr.LogHeader=Par défaut (case décochée), le client UpdatEngine enregitrera ses évenements dans le répertoire d'installation.
+fr.LogBox=Cochez cette case pour désactiver la journalisation du client UpdatEngine
 
 [Code]
 var    
@@ -148,10 +161,14 @@ var
   InventoryPage: TInputOptionWizardPage;
   ProxyPage: TInputOptionWizardPage;
   SslCertificatePage: TInputFileWizardPage;
+  LogPage: TInputOptionWizardPage;
+
+// Define function prototype
+function CmdLineParamExists(const Value: string): Boolean; forward;
 
 // --------------------------------
 // Wizard initialization : Create the pages 
-procedure InitializeWizard;        
+procedure InitializeWizard;     
 begin
   { Config page }
   ConfigPage := CreateInputQueryPage(wpLicense,
@@ -159,19 +176,43 @@ begin
     expandConstant('{cm:TipsConfiguration}'));
   ConfigPage.Add(expandConstant('{cm:Server}'), False);
   ConfigPage.Add(expandConstant('{cm:Delay}'), False);
-
+  
   ConfigPage.Values[0] := GetPreviousData('Server', ExpandConstant('{cm:UrlValue}'));
   ConfigPage.Values[1] := GetPreviousData('Delay', '30');
 
+  if length(ExpandConstant('{param:server}')) > 0 then
+    ConfigPage.Values[0] := ExpandConstant('{param:server}');
+  if StrToInt(ExpandConstant('{param:delay|0}')) > 0 then
+    ConfigPage.Values[1] := ExpandConstant('{param:delay}');
+
+  { Certificate page }
+  SslCertificatePage := CreateInputFilePage(ConfigPage.ID,
+    expandConstant('{cm:SslCertificate}'), expandConstant('{cm:SslTips}'),
+    expandConstant('{cm:SslWarning}'));  
+  SslCertificatePage.Add(expandConstant('{cm:SslField}'),
+    expandConstant('{cm:PemFiles}|*.pem|{cm:AllFiles}|*.*'), '.pem');
+
+  SslCertificatePage.Values[0] := GetPreviousData('SSLcertificat', '');
+
+  if length(ExpandConstant('{param:cert}')) > 0 then
+    SslCertificatePage.Values[0] := ExpandConstant('{param:cert}')
+  else if ParamCount > 1 then
+    SslCertificatePage.Values[0] := '';
+
   { Inventory page }
-  InventoryPage := CreateInputOptionPage(ConfigPage.ID,
+  InventoryPage := CreateInputOptionPage(SslCertificatePage.ID,
     expandConstant('{cm:NoInstallInventoryTitle}'), expandConstant('{cm:NoInstallInventoryDescription}'),
     expandConstant('{cm:NoInstallInventoryHeader}'),
     False, False);
-  InventoryPage.Add(expandConstant('{cm:NoInstallInventory}'));
-  
+  InventoryPage.Add(expandConstant('{cm:NoInstallInventoryBox}'));
+
   if GetPreviousData('NoInstallInventory', '') = 'True' then
     InventoryPage.Values[0] := True;
+
+  if CmdLineParamExists('/noinventorynow') = True then
+    InventoryPage.Values[0] := True
+  else if ParamCount > 1 then
+    InventoryPage.Values[0] := False;
 
   { Proxy page }
   ProxyPage := CreateInputOptionPage(InventoryPage.ID,
@@ -180,17 +221,29 @@ begin
     False, False);
   ProxyPage.Add(expandConstant('{cm:ProxyBox}'));
 
-  if GetPreviousData('ProxyBox', '') = 'True' then
+  if GetPreviousData('NoProxy', '') = 'True' then
     ProxyPage.Values[0] := True;
 
-  { Certificate page }
-  SslCertificatePage := CreateInputFilePage(ProxyPage.ID,
-    expandConstant('{cm:SslCertificate}'), expandConstant('{cm:SslTips}'),
-    expandConstant('{cm:SslWarning}'));  
-  SslCertificatePage.Add(expandConstant('{cm:SslField}'),
-    expandConstant('{cm:PemFiles}|*.pem|{cm:AllFiles}|*.*'), '.pem');
+  if CmdLineParamExists('/noproxy') = True then
+    ProxyPage.Values[0] := True
+  else if ParamCount > 1 then
+    ProxyPage.Values[0] := False;    
 
-  SslCertificatePage.Values[0] := GetPreviousData('SslField', '');
+  { Log page }
+  LogPage := CreateInputOptionPage(ProxyPage.ID,
+    expandConstant('{cm:LogTitle}'), expandConstant('{cm:LogDescription}'),
+    expandConstant('{cm:LogHeader}'),
+    False, False);
+  LogPage.Add(expandConstant('{cm:LogBox}'));
+
+  if GetPreviousData('NoLogging', '') = 'True' then
+    LogPage.Values[0] := True;
+
+  if CmdLineParamExists('/nolog') = True then
+    LogPage.Values[0] := True
+  else if ParamCount > 1 then
+    LogPage.Values[0] := False;
+
 end;
 
 // --------------------------------
@@ -199,11 +252,25 @@ procedure RegisterPreviousData(PreviousDataKey: Integer);
 begin  
   SetPreviousData(PreviousDataKey, 'Server', ConfigPage.Values[0]);
   SetPreviousData(PreviousDataKey, 'Delay', ConfigPage.Values[1]);
+  if (Pos('https://',LowerCase(ConfigPage.Values[0])) = 1) then
+    SetPreviousData(PreviousDataKey, 'SSLcertificat', SslCertificatePage.Values[0])
+  else SetPreviousData(PreviousDataKey, 'SSLcertificat', '');
   if InventoryPage.Values[0] = True then
     SetPreviousData(PreviousDataKey, 'NoInstallInventory', 'True');
   if ProxyPage.Values[0] = True then
-    SetPreviousData(PreviousDataKey, 'ProxyBox', 'True');
-  SetPreviousData(PreviousDataKey, 'SslField', SslCertificatePage.Values[0]);
+    SetPreviousData(PreviousDataKey, 'NoProxy', 'True');
+  if LogPage.Values[0] = True then
+    SetPreviousData(PreviousDataKey, 'NoLogging', 'True');  
+end;
+
+// --------------------------------
+// Check if certificat page is shown or skipped
+function ShouldSkipPage(PageID: Integer): Boolean;
+begin
+  Result := False; //not necessary, but safer
+  if (PageID = SslCertificatePage.ID) and
+     (Pos('https://',LowerCase(ConfigPage.Values[0])) <> 1) then
+    Result := true;
 end;
 
 // --------------------------------
@@ -220,7 +287,7 @@ begin
   // look for the path with leading and trailing semicolon
   Result := Pos(';' + UpperCase(Param) + ';', ';' + UpperCase(OrigPath) + ';') = 0;   
   if Result = True then
-     Result := Pos(';' + UpperCase(Param) + '\;', ';' + UpperCase(OrigPath) + ';') = 0; 
+    Result := Pos(';' + UpperCase(Param) + '\;', ';' + UpperCase(OrigPath) + ';') = 0; 
 end;
 
 // --------------------------------
@@ -235,8 +302,8 @@ end;
 function GetProxyOption(Value: string): string;
 begin
   if ProxyPage.Values[0] then
-    Result := '/noproxy';
-end;                   
+    Result := '-n';
+end;
 
 // --------------------------------
 // Get server string
@@ -250,7 +317,15 @@ end;
 function GetDelay(Value: string): string;
 begin
   Result := ConfigPage.Values[1];
-end;   
+end; 
+
+// --------------------------------
+// Get logging value
+function GetLogging(Value: string): string;
+begin
+  if not LogPage.Values[0] then
+    Result := ExpandConstant('-o \"{app}\updatengine-client.log\"');
+end; 
 
 // --------------------------------
 // Check if inventory is launched after installation
@@ -262,22 +337,58 @@ end;
 
 // --------------------------------
 // Check if certificat file is empty
+// -> The response is always 'True' if server url is not https
 function CheckEmptyCacert: Boolean;
 var
   Size: Integer;
 begin       
-    if not FileSize(SslCertificatePage.Values[0], Size) or (Size = 0) then
-      Result := True;
+  if (not FileSize(SslCertificatePage.Values[0], Size) or (Size = 0)) or (Pos('https://',LowerCase(ConfigPage.Values[0])) <> 1) then
+    Result := True;
 end;
 
 // --------------------------------
 // Check certificat file on next button click
 function NextButtonClick(PageId: Integer): Boolean;
 begin
-    Result := True;
-    if (PageId = SslCertificatePage.ID) and (SslCertificatePage.Values[0]<>'') and CheckEmptyCacert then begin
-        MsgBox(expandConstant('{cm:SslCertError}'), mbError, MB_OK);
-        Result := False;
-        exit;
+  Result := True;
+  if (PageId = SslCertificatePage.ID) and (SslCertificatePage.Values[0]<>'') and CheckEmptyCacert then begin
+    if ParamCount = 1 then
+      MsgBox(expandConstant('{cm:SslCertError}'), mbError, MB_OK);
+    Result := False;
+    exit;
+  end;
+end;
+
+// --------------------------------
+// Kill a Win32 process
+procedure TaskKill(FileName: String);
+var
+  ResultCode: Integer;
+begin
+  Exec('taskkill.exe', '/f /t /im ' + '"' + FileName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+end;
+
+// --------------------------------
+// Check if command line parameter exists
+function CmdLineParamExists(const Value: string): Boolean;
+var
+  I: Integer;  
+begin
+  Result := False;
+  for I := 1 to ParamCount do
+    if CompareText(ParamStr(I), Value) = 0 then
+    begin
+      Result := True;
+      Break;
     end;
 end;
+
+// --------------------------------
+// Stop previous running application if parameter is specified
+procedure CheckForceInstall();
+begin
+  if CmdLineParamExists('/forceinstall') = True then
+    TaskKill('updatengine-client.exe');
+end;
+
+// --------------------------------

--- a/Windows/version.txt
+++ b/Windows/version.txt
@@ -1,0 +1,28 @@
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=(2, 4, 9, 4),
+    prodvers=(2, 4, 9, 4),
+    mask=0x3f,
+    flags=0x0,
+    OS=0x40004,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+    ),
+  kids=[
+    StringFileInfo(
+      [
+      StringTable(
+        u'040C04E4',
+        [StringStruct(u'CompanyName', u'UpdatEngine'),
+        StringStruct(u'FileDescription', u'Windows UpdatEngine client'),
+        StringStruct(u'FileVersion', u'2.4.9.4'),
+        StringStruct(u'InternalName', u'updatengine-client'),
+        StringStruct(u'LegalCopyright', u''),
+        StringStruct(u'OriginalFilename', u'updatengine-client.exe'),
+        StringStruct(u'ProductName', u'UpdatEngine Client'),
+        StringStruct(u'ProductVersion', u'2.4.9.4')])
+      ]), 
+    VarFileInfo([VarStruct(u'Translation', [0x040C, 0x04E4])])
+  ]
+)


### PR DESCRIPTION
- The file 'build.bat' content the lines to generate a freeze with PyInstaller
- The file 'install_script.iss' is a full Inno Setup script to create a windows installer. Compared to the original installer, improvements have been added such as the recovery of the previous parameters, the default * .pem choice for the certificate and the verification that its content is not empty when selected in the wizard.